### PR TITLE
Fix reproducible AMO build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 web-ext-artifacts/
 config-prod.json
 yarn.lock
+amo-dist/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > [!IMPORTANT]
 > **UPDATE March 2026:** Unfortunately the extension is no longer available in Mozilla's Addons store.
-> 
+>
 > I recently received an email from them, saying that this extension was reported that it's not possible to build it from source.
 > And that I need fix this or they will remove it from their store.
 > 
@@ -62,15 +62,47 @@ See [a tutorial here](customization-tutorial.md)
 
 
 ## Build locally
-1. `npm i`
-2. To test the extension in a temporary firefox profile, use the test script:
-    ```sh
-    npm start
-    ```
-3. To build a zip artifact (that can be uploaded to mozilla addons):
-    ```sh
-    npm run build
-    ```
+
+### Firefox / Mozilla Add-ons build
+
+Install the exact dependency versions from the lockfile:
+
+```sh
+npm ci
+```
+
+Build the production Firefox extension:
+
+```sh
+npm run build:amo
+```
+
+The unpacked Firefox extension is generated in:
+
+```text
+amo-dist/
+```
+
+The uploadable ZIP is generated in:
+
+```text
+web-ext-artifacts/
+```
+
+Mozilla's default reviewer build environment is:
+
+* Ubuntu 24.04.4 LTS
+* ARM64
+* Node.js 24.14.0
+* npm 11.9.0
+
+### Development
+
+To test the extension in a temporary Firefox profile:
+
+```sh
+npm start
+```
 
 ## Creating test-profile in Firefox
 1. Open `about:profiles`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "perfect-home",
-	"version": "0.14.1",
+	"version": "0.14.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "perfect-home",
-			"version": "0.14.1",
+			"version": "0.14.2",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"sortablejs": "^1.15.6"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"src:start": "gulp watch",
 		"dist": "gulp build --prod",
 		"build": "gulp build && npm run ext:build",
+		"build:amo": "gulp build --prod && rm -rf amo-dist && cp -R dist amo-dist && cp LICENSE amo-dist/ && rm -f amo-dist/manifest-chrome.json && web-ext build --overwrite-dest -s ./amo-dist",
 		"watch": "run-p ext:start src:start",
 		"start": "run-s build watch"
 	},

--- a/release.js
+++ b/release.js
@@ -15,7 +15,7 @@ import Git from 'simple-git';
 const git = Git();
 const cwd = process.cwd();
 
-const manifests = ['package.json', 'src/manifest.json', 'src/manifest-chrome.json'];
+const manifests = ['package.json', 'package-lock.json', 'src/manifest.json', 'src/manifest-chrome.json'];
 const addonUrl = 'https://addons.mozilla.org/en-US/developers/addon/perfect-home/versions';
 const chromeStoreDash = 'https://chrome.google.com/webstore/devconsole';
 const dryrun = false;
@@ -62,6 +62,9 @@ function bump (manifest, newVersion) {
 	const pkg = getJson(pkgPath);
 	const usedIndent = indent(fs.readFileSync(pkgPath, 'utf8')).indent || '  ';
 	pkg.version = newVersion;
+
+	if (manifest === 'package-lock.json' && pkg.packages?.['']) pkg.packages[''].version = newVersion;
+
 	if (!dryrun) fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, usedIndent) + '\n');
 }
 
@@ -134,7 +137,7 @@ function release () {
 
 			spinner.text = 'Building a ' + chalk.cyan('production') + ' version.';
 			spinner.start();
-			return run('gulp build --prod');
+			return run('npm run build:amo');
 		})
 		.then(() => {
 			spinner.text = 'Built a ' + chalk.cyan('production') + ' version.';
@@ -145,9 +148,7 @@ function release () {
 
 			const cmd = `rm -rf ~/Desktop/${app.name} && ` +
 				`mkdir ~/Desktop/${app.name} && ` +
-				`cp -R dist/ ~/Desktop/${app.name} && ` +
-				`cp LICENSE ~/Desktop/${app.name} && ` +
-				`rm -f ~/Desktop/${app.name}/manifest-chrome.json && ` +
+				`cp -R amo-dist/. ~/Desktop/${app.name}/ && ` +
 
 				// zip for firefox
 				`7zz a ~/Desktop/${app.name}-firefox.zip ~/Desktop/${app.name}/* && ` +
@@ -173,6 +174,8 @@ function release () {
 				`cp -R src/ ~/Desktop/${app.name}/src/ && ` +
 				`cp LICENSE ~/Desktop/${app.name} && ` +
 				`cp package.json ~/Desktop/${app.name} && ` +
+				`cp package-lock.json ~/Desktop/${app.name} && ` +
+				`cp .npmrc ~/Desktop/${app.name} && ` +
 				`cp gulpfile.js ~/Desktop/${app.name} && ` +
 				`cp .editorconfig ~/Desktop/${app.name} && ` +
 				`cp .eslintrc ~/Desktop/${app.name} && ` +

--- a/src/folders/Folders.svelte
+++ b/src/folders/Folders.svelte
@@ -9,7 +9,7 @@
 
 <script>
 import { onMount } from 'svelte';
-import Folder from './Folder.svelte';
+import Folder from './folder.svelte';
 import { EVENT, getBookmark, dockedFolders } from '../lib';
 let settingsLoaded = false;
 let foldersLoaded = false;


### PR DESCRIPTION
This PR fixes several issues that can prevent Mozilla reviewers from rebuilding the Firefox extension from the submitted source.

I found that the documented build command and the production release build produced different output. The normal build includes source maps and non-minified assets, while the production release uses `gulp build --prod`.

Changes in this PR:

- Add `npm run build:amo` for the production Firefox/AMO build
- Prepare a Firefox-only build tree in `amo-dist/`
- Exclude `manifest-chrome.json` from the AMO build
- Include `LICENSE` in the generated Firefox package
- Include `package-lock.json` and `.npmrc` in the AMO source archive
- Keep the package-lock version synchronized during releases
- Fix the existing package-lock version mismatch (`0.14.1` vs `0.14.2`)
- Update the README with the exact AMO build instructions
- Fix the case-sensitive `Folder.svelte` import (on a case-sensitive filesystem this causes the build to fail with ENOENT)

I also tested the source package from a completely separate clean directory:

npm ci
npm run build:amo

The build completed successfully and generated the Firefox package with `manifest.json` and `LICENSE`, without `manifest-chrome.json`.

Hopefully this makes the source submitted to AMO reproducible in their review environment.